### PR TITLE
Delete the reference operators on singletons for better safety

### DIFF
--- a/ggp-engine/InputManager.h
+++ b/ggp-engine/InputManager.h
@@ -31,6 +31,10 @@ public:
 	static InputManager* GetInstance();
 	static void ReleaseInstance();
 
+    // We don't want anything making copies of this class so delete these operators
+    InputManager( InputManager const& ) = delete;
+    void operator=( InputManager const& ) = delete;
+
 	//Main update function
 	void Update();
 

--- a/ggp-engine/LightManager.h
+++ b/ggp-engine/LightManager.h
@@ -33,6 +33,10 @@ public:
 	static LightManager* GetInstance();
 	static void ReleaseInstance();
 
+    // We don't want anything making copies of this class so delete these operators
+    LightManager( LightManager const& ) = delete;
+    void operator=( LightManager const& ) = delete;
+
 	void UploadAllLights(SimplePixelShader* _pixelShader);
 
 	/*

--- a/ggp-engine/RenderManager.h
+++ b/ggp-engine/RenderManager.h
@@ -38,6 +38,10 @@ public:
 	static RenderManager* GetInstance();
 	static void ReleaseInstance();
 
+    // We don't want anything making copies of this class so delete these operators
+    RenderManager( RenderManager const& ) = delete;
+    void operator=( RenderManager const& ) = delete;
+
 	//Start method.  Called once when we can safely assume the entire engine has been initialized
 	void Start();
 

--- a/ggp-engine/ResourceManager.h
+++ b/ggp-engine/ResourceManager.h
@@ -32,6 +32,11 @@ class ResourceManager {
 public:
 	static ResourceManager* GetInstance();
 	static void ReleaseInstance();
+
+    // We don't want anything making copies of this class so delete these operators
+    ResourceManager( ResourceManager const& ) = delete;
+    void operator=( ResourceManager const& ) = delete;
+
 	//Sets the device and context needed to actually interact with the window
 	static void SetDevicePointer(ID3D11Device* _dxDevice);
 	static void SetContextPointer(ID3D11DeviceContext* _dxContext);


### PR DESCRIPTION
Deleting those operators makes it more explicit that those classes should not be copied because they are singletons. 